### PR TITLE
Enable moderation level in edit mode

### DIFF
--- a/src/app/api/images/route.ts
+++ b/src/app/api/images/route.ts
@@ -128,6 +128,7 @@ export async function POST(request: NextRequest) {
             const n = parseInt((formData.get('n') as string) || '1', 10);
             const size = (formData.get('size') as OpenAI.Images.ImageEditParams['size']) || 'auto';
             const quality = (formData.get('quality') as OpenAI.Images.ImageEditParams['quality']) || 'auto';
+            const moderation = (formData.get('moderation') as OpenAI.Images.ImageEditParams['moderation']) || 'auto';
 
             const imageFiles: File[] = [];
             for (const [key, value] of formData.entries()) {
@@ -148,7 +149,8 @@ export async function POST(request: NextRequest) {
                 image: imageFiles,
                 n: Math.max(1, Math.min(n || 1, 10)),
                 size: size === 'auto' ? undefined : size,
-                quality: quality === 'auto' ? undefined : quality
+                quality: quality === 'auto' ? undefined : quality,
+                moderation
             };
 
             if (maskFile) {
@@ -158,7 +160,8 @@ export async function POST(request: NextRequest) {
             console.log('Calling OpenAI edit with params:', {
                 ...params,
                 image: `[${imageFiles.map((f) => f.name).join(', ')}]`,
-                mask: maskFile ? maskFile.name : 'N/A'
+                mask: maskFile ? maskFile.name : 'N/A',
+                moderation
             });
             result = await openai.images.edit(params);
         } else {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -91,6 +91,7 @@ export default function HomePage() {
     const [editN, setEditN] = React.useState([1]);
     const [editSize, setEditSize] = React.useState<EditingFormData['size']>('auto');
     const [editQuality, setEditQuality] = React.useState<EditingFormData['quality']>('auto');
+    const [editModeration, setEditModeration] = React.useState<EditingFormData['moderation']>('auto');
     const [editBrushSize, setEditBrushSize] = React.useState([20]);
     const [editShowMaskEditor, setEditShowMaskEditor] = React.useState(false);
     const [editGeneratedMaskFile, setEditGeneratedMaskFile] = React.useState<File | null>(null);
@@ -341,6 +342,7 @@ export default function HomePage() {
             apiFormData.append('n', editN[0].toString());
             apiFormData.append('size', editSize);
             apiFormData.append('quality', editQuality);
+            apiFormData.append('moderation', editModeration);
 
             editImageFiles.forEach((file, index) => {
                 apiFormData.append(`image_${index}`, file, file.name);
@@ -393,7 +395,7 @@ export default function HomePage() {
                 } else {
                     historyQuality = editQuality;
                     historyBackground = 'auto';
-                    historyModeration = 'auto';
+                    historyModeration = editModeration;
                     historyOutputFormat = 'png';
                     historyPrompt = editPrompt;
                 }
@@ -762,6 +764,8 @@ export default function HomePage() {
                                 setEditSize={setEditSize}
                                 editQuality={editQuality}
                                 setEditQuality={setEditQuality}
+                                editModeration={editModeration}
+                                setEditModeration={setEditModeration}
                                 editBrushSize={editBrushSize}
                                 setEditBrushSize={setEditBrushSize}
                                 editShowMaskEditor={editShowMaskEditor}

--- a/src/components/editing-form.tsx
+++ b/src/components/editing-form.tsx
@@ -20,6 +20,8 @@ import {
     Tally2,
     Tally3,
     Loader2,
+    ShieldCheck,
+    ShieldAlert,
     X,
     ScanEye,
     UploadCloud,
@@ -40,6 +42,7 @@ export type EditingFormData = {
     n: number;
     size: '1024x1024' | '1536x1024' | '1024x1536' | 'auto';
     quality: 'low' | 'medium' | 'high' | 'auto';
+    moderation: 'low' | 'auto';
     imageFiles: File[];
     maskFile: File | null;
 };
@@ -65,6 +68,8 @@ type EditingFormProps = {
     setEditSize: React.Dispatch<React.SetStateAction<EditingFormData['size']>>;
     editQuality: EditingFormData['quality'];
     setEditQuality: React.Dispatch<React.SetStateAction<EditingFormData['quality']>>;
+    editModeration: EditingFormData['moderation'];
+    setEditModeration: React.Dispatch<React.SetStateAction<EditingFormData['moderation']>>;
     editBrushSize: number[];
     setEditBrushSize: React.Dispatch<React.SetStateAction<number[]>>;
     editShowMaskEditor: boolean;
@@ -126,6 +131,8 @@ export function EditingForm({
     setEditSize,
     editQuality,
     setEditQuality,
+    editModeration,
+    setEditModeration,
     editBrushSize,
     setEditBrushSize,
     editShowMaskEditor,
@@ -438,6 +445,7 @@ export function EditingForm({
             n: editN[0],
             size: editSize,
             quality: editQuality,
+            moderation: editModeration,
             imageFiles: imageFiles,
             maskFile: editGeneratedMaskFile
         };
@@ -712,6 +720,18 @@ export function EditingForm({
                             <RadioItemWithIcon value='low' id='edit-quality-low' label='Low' Icon={Tally1} />
                             <RadioItemWithIcon value='medium' id='edit-quality-medium' label='Medium' Icon={Tally2} />
                             <RadioItemWithIcon value='high' id='edit-quality-high' label='High' Icon={Tally3} />
+                        </RadioGroup>
+                    </div>
+
+                    <div className='space-y-3'>
+                        <Label className='block text-white'>Moderation Level</Label>
+                        <RadioGroup
+                            value={editModeration}
+                            onValueChange={(value) => setEditModeration(value as EditingFormData['moderation'])}
+                            disabled={isLoading}
+                            className='flex flex-wrap gap-x-5 gap-y-3'>
+                            <RadioItemWithIcon value='auto' id='edit-mod-auto' label='Auto' Icon={ShieldCheck} />
+                            <RadioItemWithIcon value='low' id='edit-mod-low' label='Low' Icon={ShieldAlert} />
                         </RadioGroup>
                     </div>
 


### PR DESCRIPTION
## Summary
- extend `EditingFormData` with `moderation`
- add moderation controls to the edit form UI
- plumb moderation state through `page.tsx`
- send moderation to backend when editing
- support moderation param in API edit route

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684aa3ad8a7c83239a90aeccfaaa0f6a